### PR TITLE
Migrate deprecated AllBranchesLogCmd to AllBranchesLogCmds

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -335,9 +335,9 @@ git:
   # Command used when displaying the current branch git log in the main window
   branchLogCmd: git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --
 
-  # Command used to display git log of all branches in the main window.
-  # Deprecated: Use `allBranchesLogCmds` instead.
-  allBranchesLogCmd: git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium
+  # Commands used to display git log of all branches in the main window, they will be cycled in order of appearance
+  allBranchesLogCmds:
+    - git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium
 
   # If true, do not spawn a separate process when using GPG
   overrideGpg: false

--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -1,6 +1,6 @@
 # Custom Command Keybindings
 
-You can add custom command keybindings in your config.yml (accessible by pressing 'o' on the status panel from within lazygit) like so:
+You can add custom command keybindings in your config.yml (accessible by pressing 'e' on the status panel from within lazygit) like so:
 
 ```yml
 customCommands:

--- a/docs/Custom_Command_Keybindings.md
+++ b/docs/Custom_Command_Keybindings.md
@@ -324,6 +324,27 @@ We don't support accessing all elements of a range selection yet. We might add t
 
 If your custom keybinding collides with an inbuilt keybinding that is defined for the same context, only the custom keybinding will be executed. This also applies to the global context. However, one caveat is that if you have a custom keybinding defined on the global context for some key, and there is an in-built keybinding defined for the same key and for a specific context (say the 'files' context), then the in-built keybinding will take precedence. See how to change in-built keybindings [here](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#keybindings)
 
+## Menus of custom commands
+
+For custom commands that are not used very frequently it may be preferable to hide them in a menu; you can assign a key to open the menu, and the commands will appear inside. This has the advantage that you don't have to come up with individual unique keybindings for all those commands that you don't use often; the keybindings for the commands in the menu only need to be unique within the menu. Here is an example:
+
+```yml
+customCommands:
+- key: X
+  description: "Copy/paste commits across repos"
+  commandMenu:
+  - key: c
+    command: 'git format-patch --stdout {{.SelectedCommitRange.From}}^..{{.SelectedCommitRange.To}} | pbcopy'
+    context: commits, subCommits
+    description: "Copy selected commits to clipboard"
+  - key: v
+    command: 'pbpaste | git am'
+    context: "commits"
+    description: "Paste selected commits from clipboard"
+```
+
+If you use the commandMenu property, none of the other properties except key and description can be used.
+
 ## Debugging
 
 If you want to verify that your command actually does what you expect, you can wrap it in an 'echo' call and set `showOutput: true` so that it doesn't actually execute the command but you can see how the placeholders were resolved.

--- a/pkg/commands/git_commands/branch.go
+++ b/pkg/commands/git_commands/branch.go
@@ -248,11 +248,7 @@ func (self *BranchCommands) Merge(branchName string, opts MergeOpts) error {
 
 func (self *BranchCommands) AllBranchesLogCmdObj() oscommands.ICmdObj {
 	// Only choose between non-empty, non-identical commands
-	candidates := lo.Uniq(lo.WithoutEmpty(append([]string{
-		self.UserConfig().Git.AllBranchesLogCmd,
-	},
-		self.UserConfig().Git.AllBranchesLogCmds...,
-	)))
+	candidates := lo.Uniq(lo.WithoutEmpty(self.UserConfig().Git.AllBranchesLogCmds))
 
 	n := len(candidates)
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -281,6 +281,11 @@ func computeMigratedConfig(path string, content []byte) ([]byte, error) {
 		return nil, fmt.Errorf("Couldn't migrate config file at `%s`: %s", path, err)
 	}
 
+	err = migrateAllBranchesLogCmd(&rootNode)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't migrate config file at `%s`: %s", path, err)
+	}
+
 	// Add more migrations here...
 
 	if !reflect.DeepEqual(rootNode, originalCopy) {
@@ -337,6 +342,44 @@ func changeCommitPrefixesMap(rootNode *yaml.Node) error {
 				}
 			}
 		}
+		return nil
+	})
+}
+
+// This migration is special because users have already defined
+// a single elemnt at `allBranchesLogCmd` and the sequence at `allBranchesLogCmds`.
+// Some users have explicitly set `allBranchesLogCmd` to be an empty string in order
+// to remove it, so in that case we just delete the element, and add nothing to the list
+func migrateAllBranchesLogCmd(rootNode *yaml.Node) error {
+	return yaml_utils.TransformNode(rootNode, []string{"git"}, func(gitNode *yaml.Node) error {
+		cmdKeyNode, cmdValueNode := yaml_utils.LookupKey(gitNode, "allBranchesLogCmd")
+		// Nothing to do if they do not have the deprecated item
+		if cmdKeyNode == nil {
+			return nil
+		}
+
+		cmdsKeyNode, cmdsValueNode := yaml_utils.LookupKey(gitNode, "allBranchesLogCmds")
+		if cmdsKeyNode == nil {
+			// Create dummy node and attach it onto the root git node
+			cmdsKeyNode = &yaml.Node{Kind: yaml.ScalarNode, Value: "allBranchesLogCmds"}
+			cmdsValueNode = &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{}}
+			gitNode.Content = append(gitNode.Content,
+				cmdsKeyNode,
+				cmdsValueNode,
+			)
+		}
+
+		if cmdValueNode.Value != "" {
+			if cmdsValueNode.Kind != yaml.SequenceNode {
+				return fmt.Errorf("You should have an allBranchesLogCmds defined as a sequence!")
+			}
+			// Prepending the individual element to make it show up first in the list, which was prior behavior
+			cmdsValueNode.Content = append([]*yaml.Node{{Kind: yaml.ScalarNode, Value: cmdValueNode.Value}}, cmdsValueNode.Content...)
+		}
+
+		// Clear out the existing allBranchesLogCmd, now that we have migrated it into the list
+		_, _ = yaml_utils.RemoveKey(gitNode, "allBranchesLogCmd")
+
 		return nil
 	})
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -249,9 +249,6 @@ type GitConfig struct {
 	AutoStageResolvedConflicts bool `yaml:"autoStageResolvedConflicts"`
 	// Command used when displaying the current branch git log in the main window
 	BranchLogCmd string `yaml:"branchLogCmd"`
-	// Command used to display git log of all branches in the main window.
-	// Deprecated: Use `allBranchesLogCmds` instead.
-	AllBranchesLogCmd string `yaml:"allBranchesLogCmd"`
 	// Commands used to display git log of all branches in the main window, they will be cycled in order of appearance
 	AllBranchesLogCmds []string `yaml:"allBranchesLogCmds"`
 	// If true, do not spawn a separate process when using GPG
@@ -801,7 +798,7 @@ func GetDefaultConfig() *UserConfig {
 			FetchAll:                     true,
 			AutoStageResolvedConflicts:   true,
 			BranchLogCmd:                 "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --",
-			AllBranchesLogCmd:            "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium",
+			AllBranchesLogCmds:           []string{"git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"},
 			DisableForcePushing:          false,
 			CommitPrefixes:               map[string][]CommitPrefixConfig(nil),
 			BranchPrefix:                 "",

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -640,6 +640,14 @@ type CustomCommand struct {
 	After *CustomCommandAfterHook `yaml:"after"`
 }
 
+func (c *CustomCommand) GetDescription() string {
+	if c.Description != "" {
+		return c.Description
+	}
+
+	return c.Command
+}
+
 type CustomCommandPrompt struct {
 	// One of: 'input' | 'menu' | 'confirm' | 'menuFromCommand'
 	Type string `yaml:"type"`

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -619,7 +619,8 @@ type CustomCommand struct {
 	// The command to run (using Go template syntax for placeholder values)
 	Command string `yaml:"command" jsonschema:"example=git fetch {{.Form.Remote}} {{.Form.Branch}} && git checkout FETCH_HEAD"`
 	// If true, run the command in a subprocess (e.g. if the command requires user input)
-	Subprocess bool `yaml:"subprocess"`
+	// [dev] Pointer to bool so that we can distinguish unset (nil) from false.
+	Subprocess *bool `yaml:"subprocess"`
 	// A list of prompts that will request user input before running the final command
 	Prompts []CustomCommandPrompt `yaml:"prompts"`
 	// Text to display while waiting for command to finish
@@ -627,13 +628,16 @@ type CustomCommand struct {
 	// Label for the custom command when displayed in the keybindings menu
 	Description string `yaml:"description"`
 	// If true, stream the command's output to the Command Log panel
-	Stream bool `yaml:"stream"`
+	// [dev] Pointer to bool so that we can distinguish unset (nil) from false.
+	Stream *bool `yaml:"stream"`
 	// If true, show the command's output in a popup within Lazygit
-	ShowOutput bool `yaml:"showOutput"`
+	// [dev] Pointer to bool so that we can distinguish unset (nil) from false.
+	ShowOutput *bool `yaml:"showOutput"`
 	// The title to display in the popup panel if showOutput is true. If left unset, the command will be used as the title.
 	OutputTitle string `yaml:"outputTitle"`
 	// Actions to take after the command has completed
-	After CustomCommandAfterHook `yaml:"after"`
+	// [dev] Pointer so that we can tell whether it appears in the config file
+	After *CustomCommandAfterHook `yaml:"after"`
 }
 
 type CustomCommandPrompt struct {

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -614,6 +614,9 @@ type CustomCommandAfterHook struct {
 type CustomCommand struct {
 	// The key to trigger the command. Use a single letter or one of the values from https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md
 	Key string `yaml:"key"`
+	// Instead of defining a single custom command, create a menu of custom commands. Useful for grouping related commands together under a single keybinding, and for keeping them out of the global keybindings menu.
+	// When using this, all other fields except Key and Description are ignored and must be empty.
+	CommandMenu []CustomCommand `yaml:"commandMenu"`
 	// The context in which to listen for the key. Valid values are: status, files, worktrees, localBranches, remotes, remoteBranches, tags, commits, reflogCommits, subCommits, commitFiles, stash, and global. Multiple contexts separated by comma are allowed; most useful for "commits, subCommits" or "files, commitFiles".
 	Context string `yaml:"context" jsonschema:"example=status,example=files,example=worktrees,example=localBranches,example=remotes,example=remoteBranches,example=tags,example=commits,example=reflogCommits,example=subCommits,example=commitFiles,example=stash,example=global"`
 	// The command to run (using Go template syntax for placeholder values)

--- a/pkg/config/user_config_validation.go
+++ b/pkg/config/user_config_validation.go
@@ -96,6 +96,23 @@ func validateCustomCommands(customCommands []CustomCommand) error {
 		if err := validateCustomCommandKey(customCommand.Key); err != nil {
 			return err
 		}
+
+		if len(customCommand.CommandMenu) > 0 &&
+			(len(customCommand.Context) > 0 ||
+				len(customCommand.Command) > 0 ||
+				customCommand.Subprocess != nil ||
+				len(customCommand.Prompts) > 0 ||
+				len(customCommand.LoadingText) > 0 ||
+				customCommand.Stream != nil ||
+				customCommand.ShowOutput != nil ||
+				len(customCommand.OutputTitle) > 0 ||
+				customCommand.After != nil) {
+			commandRef := ""
+			if len(customCommand.Key) > 0 {
+				commandRef = fmt.Sprintf(" with key '%s'", customCommand.Key)
+			}
+			return fmt.Errorf("Error with custom command%s: it is not allowed to use both commandMenu and any of the other fields except key and description.", commandRef)
+		}
 	}
 	return nil
 }

--- a/pkg/config/user_config_validation_test.go
+++ b/pkg/config/user_config_validation_test.go
@@ -74,6 +74,58 @@ func TestUserConfigValidate_enums(t *testing.T) {
 				{value: "invalid_value", valid: false},
 			},
 		},
+		{
+			name: "Custom command sub menu",
+			setup: func(config *UserConfig, _ string) {
+				config.CustomCommands = []CustomCommand{
+					{
+						Key:         "X",
+						Description: "My Custom Commands",
+						CommandMenu: []CustomCommand{
+							{Key: "1", Command: "echo 'hello'", Context: "global"},
+						},
+					},
+				}
+			},
+			testCases: []testCase{
+				{value: "", valid: true},
+			},
+		},
+		{
+			name: "Custom command sub menu",
+			setup: func(config *UserConfig, _ string) {
+				config.CustomCommands = []CustomCommand{
+					{
+						Key:     "X",
+						Context: "global",
+						CommandMenu: []CustomCommand{
+							{Key: "1", Command: "echo 'hello'", Context: "global"},
+						},
+					},
+				}
+			},
+			testCases: []testCase{
+				{value: "", valid: false},
+			},
+		},
+		{
+			name: "Custom command sub menu",
+			setup: func(config *UserConfig, _ string) {
+				falseVal := false
+				config.CustomCommands = []CustomCommand{
+					{
+						Key:        "X",
+						Subprocess: &falseVal,
+						CommandMenu: []CustomCommand{
+							{Key: "1", Command: "echo 'hello'", Context: "global"},
+						},
+					},
+				}
+			},
+			testCases: []testCase{
+				{value: "", valid: false},
+			},
+		},
 	}
 
 	for _, s := range scenarios {

--- a/pkg/gui/services/custom_commands/client.go
+++ b/pkg/gui/services/custom_commands/client.go
@@ -1,15 +1,19 @@
 package custom_commands
 
 import (
-	"github.com/jesseduffield/lazygit/pkg/common"
+	"github.com/jesseduffield/gocui"
+	"github.com/jesseduffield/lazygit/pkg/config"
 	"github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers"
+	"github.com/jesseduffield/lazygit/pkg/gui/keybindings"
 	"github.com/jesseduffield/lazygit/pkg/gui/types"
+	"github.com/jesseduffield/lazygit/pkg/i18n"
+	"github.com/samber/lo"
 )
 
 // Client is the entry point to this package. It returns a list of keybindings based on the config's user-defined custom commands.
 // See https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Command_Keybindings.md for more info.
 type Client struct {
-	c                 *common.Common
+	c                 *helpers.HelperCommon
 	handlerCreator    *HandlerCreator
 	keybindingCreator *KeybindingCreator
 }
@@ -28,7 +32,7 @@ func NewClient(
 	keybindingCreator := NewKeybindingCreator(c)
 
 	return &Client{
-		c:                 c.Common,
+		c:                 c,
 		keybindingCreator: keybindingCreator,
 		handlerCreator:    handlerCreator,
 	}
@@ -37,13 +41,81 @@ func NewClient(
 func (self *Client) GetCustomCommandKeybindings() ([]*types.Binding, error) {
 	bindings := []*types.Binding{}
 	for _, customCommand := range self.c.UserConfig().CustomCommands {
-		handler := self.handlerCreator.call(customCommand)
-		compoundBindings, err := self.keybindingCreator.call(customCommand, handler)
-		if err != nil {
-			return nil, err
+		if len(customCommand.CommandMenu) > 0 {
+			handler := func() error {
+				return self.showCustomCommandsMenu(customCommand)
+			}
+			bindings = append(bindings, &types.Binding{
+				ViewName:    "", // custom commands menus are global; we filter the commands inside by context
+				Key:         keybindings.GetKey(customCommand.Key),
+				Modifier:    gocui.ModNone,
+				Handler:     handler,
+				Description: getCustomCommandsMenuDescription(customCommand, self.c.Tr),
+				OpensMenu:   true,
+			})
+		} else {
+			handler := self.handlerCreator.call(customCommand)
+			compoundBindings, err := self.keybindingCreator.call(customCommand, handler)
+			if err != nil {
+				return nil, err
+			}
+			bindings = append(bindings, compoundBindings...)
 		}
-		bindings = append(bindings, compoundBindings...)
 	}
 
 	return bindings, nil
+}
+
+func (self *Client) showCustomCommandsMenu(customCommand config.CustomCommand) error {
+	menuItems := make([]*types.MenuItem, 0, len(customCommand.CommandMenu))
+	for _, subCommand := range customCommand.CommandMenu {
+		if len(subCommand.CommandMenu) > 0 {
+			handler := func() error {
+				return self.showCustomCommandsMenu(subCommand)
+			}
+			menuItems = append(menuItems, &types.MenuItem{
+				Label:     subCommand.GetDescription(),
+				Key:       keybindings.GetKey(subCommand.Key),
+				OnPress:   handler,
+				OpensMenu: true,
+			})
+		} else {
+			if subCommand.Context != "" && subCommand.Context != "global" {
+				viewNames, err := self.keybindingCreator.getViewNamesAndContexts(subCommand)
+				if err != nil {
+					return err
+				}
+
+				currentView := self.c.GocuiGui().CurrentView()
+				enabled := currentView != nil && lo.Contains(viewNames, currentView.Name())
+				if !enabled {
+					continue
+				}
+			}
+
+			menuItems = append(menuItems, &types.MenuItem{
+				Label:   subCommand.GetDescription(),
+				Key:     keybindings.GetKey(subCommand.Key),
+				OnPress: self.handlerCreator.call(subCommand),
+			})
+		}
+	}
+
+	if len(menuItems) == 0 {
+		menuItems = append(menuItems, &types.MenuItem{
+			Label:   self.c.Tr.NoApplicableCommandsInThisContext,
+			OnPress: func() error { return nil },
+		})
+	}
+
+	title := getCustomCommandsMenuDescription(customCommand, self.c.Tr)
+	return self.c.Menu(types.CreateMenuOptions{Title: title, Items: menuItems, HideCancel: true})
+}
+
+func getCustomCommandsMenuDescription(customCommand config.CustomCommand, tr *i18n.TranslationSet) string {
+	if customCommand.Description != "" {
+		return customCommand.Description
+	}
+
+	return tr.CustomCommands
 }

--- a/pkg/gui/services/custom_commands/handler_creator.go
+++ b/pkg/gui/services/custom_commands/handler_creator.go
@@ -261,7 +261,7 @@ func (self *HandlerCreator) finalHandler(customCommand config.CustomCommand, ses
 
 	cmdObj := self.c.OS().Cmd.NewShell(cmdStr)
 
-	if customCommand.Subprocess {
+	if customCommand.Subprocess != nil && *customCommand.Subprocess {
 		return self.c.RunSubprocessAndRefresh(cmdObj)
 	}
 
@@ -273,7 +273,7 @@ func (self *HandlerCreator) finalHandler(customCommand config.CustomCommand, ses
 	return self.c.WithWaitingStatus(loadingText, func(gocui.Task) error {
 		self.c.LogAction(self.c.Tr.Actions.CustomCommand)
 
-		if customCommand.Stream {
+		if customCommand.Stream != nil && *customCommand.Stream {
 			cmdObj.StreamOutput()
 		}
 		output, err := cmdObj.RunWithOutput()
@@ -283,14 +283,14 @@ func (self *HandlerCreator) finalHandler(customCommand config.CustomCommand, ses
 		}
 
 		if err != nil {
-			if customCommand.After.CheckForConflicts {
+			if customCommand.After != nil && customCommand.After.CheckForConflicts {
 				return self.mergeAndRebaseHelper.CheckForConflicts(err)
 			}
 
 			return err
 		}
 
-		if customCommand.ShowOutput {
+		if customCommand.ShowOutput != nil && *customCommand.ShowOutput {
 			if strings.TrimSpace(output) == "" {
 				output = self.c.Tr.EmptyOutput
 			}

--- a/pkg/gui/services/custom_commands/keybinding_creator.go
+++ b/pkg/gui/services/custom_commands/keybinding_creator.go
@@ -34,18 +34,13 @@ func (self *KeybindingCreator) call(customCommand config.CustomCommand, handler 
 		return nil, err
 	}
 
-	description := customCommand.Description
-	if description == "" {
-		description = customCommand.Command
-	}
-
 	return lo.Map(viewNames, func(viewName string, _ int) *types.Binding {
 		return &types.Binding{
 			ViewName:    viewName,
 			Key:         keybindings.GetKey(customCommand.Key),
 			Modifier:    gocui.ModNone,
 			Handler:     handler,
-			Description: description,
+			Description: customCommand.GetDescription(),
 		}
 	}), nil
 }

--- a/pkg/gui/services/custom_commands/models.go
+++ b/pkg/gui/services/custom_commands/models.go
@@ -14,8 +14,8 @@ import (
 // compatibility. We already did this for Commit.Sha, which was renamed to Hash.
 
 type Commit struct {
-	Hash          string // deprecated: use Sha
-	Sha           string
+	Hash          string
+	Sha           string // deprecated: use Hash
 	Name          string
 	Status        models.CommitStatus
 	Action        todo.TodoCommand

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -843,6 +843,8 @@ type TranslationSet struct {
 	RangeSelectNotSupportedForSubmodules     string
 	OldCherryPickKeyWarning                  string
 	CommandDoesNotSupportOpeningInEditor     string
+	CustomCommands                           string
+	NoApplicableCommandsInThisContext        string
 	Actions                                  Actions
 	Bisect                                   Bisect
 	Log                                      Log
@@ -1879,6 +1881,8 @@ func EnglishTranslationSet() *TranslationSet {
 		RangeSelectNotSupportedForSubmodules:     "Range select not supported for submodules",
 		OldCherryPickKeyWarning:                  "The 'c' key is no longer the default key for copying commits to cherry pick. Please use `{{.copy}}` instead (and `{{.paste}}` to paste). The reason for this change is that the 'v' key for selecting a range of lines when staging is now also used for selecting a range of lines in any list view, meaning that we needed to find a new key for pasting commits, and if we're going to now use `{{.paste}}` for pasting commits, we may as well use `{{.copy}}` for copying them. If you want to configure the keybindings to get the old behaviour, set the following in your config:\n\nkeybinding:\n  universal:\n    toggleRangeSelect: <something other than v>\n  commits:\n    cherryPickCopy: 'c'\n    pasteCommits: 'v'",
 		CommandDoesNotSupportOpeningInEditor:     "This command doesn't support switching to the editor",
+		CustomCommands:                           "Custom commands",
+		NoApplicableCommandsInThisContext:        "(No applicable commands in this context)",
 
 		Actions: Actions{
 			// TODO: combine this with the original keybinding descriptions (those are all in lowercase atm)

--- a/pkg/integration/tests/custom_commands/check_for_conflicts.go
+++ b/pkg/integration/tests/custom_commands/check_for_conflicts.go
@@ -19,7 +19,7 @@ var CheckForConflicts = NewIntegrationTest(NewIntegrationTestArgs{
 				Key:     "m",
 				Context: "localBranches",
 				Command: "git merge {{ .SelectedLocalBranch.Name | quote }}",
-				After: config.CustomCommandAfterHook{
+				After: &config.CustomCommandAfterHook{
 					CheckForConflicts: true,
 				},
 			},

--- a/pkg/integration/tests/custom_commands/custom_commands_submenu.go
+++ b/pkg/integration/tests/custom_commands/custom_commands_submenu.go
@@ -1,0 +1,75 @@
+package custom_commands
+
+import (
+	"github.com/jesseduffield/lazygit/pkg/config"
+	. "github.com/jesseduffield/lazygit/pkg/integration/components"
+)
+
+var CustomCommandsSubmenu = NewIntegrationTest(NewIntegrationTestArgs{
+	Description:  "Using custom commands from a custom commands menu",
+	ExtraCmdArgs: []string{},
+	Skip:         false,
+	SetupRepo:    func(shell *Shell) {},
+	SetupConfig: func(cfg *config.AppConfig) {
+		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
+			{
+				Key:         "x",
+				Description: "My Custom Commands",
+				CommandMenu: []config.CustomCommand{
+					{
+						Key:     "1",
+						Context: "global",
+						Command: "touch myfile-global",
+					},
+					{
+						Key:     "2",
+						Context: "files",
+						Command: "touch myfile-files",
+					},
+					{
+						Key:     "3",
+						Context: "commits",
+						Command: "touch myfile-commits",
+					},
+				},
+			},
+		}
+	},
+	Run: func(t *TestDriver, keys config.KeybindingConfig) {
+		t.Views().Files().
+			Focus().
+			IsEmpty().
+			Press("x").
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("My Custom Commands")).
+					Lines(
+						Contains("1 touch myfile-global"),
+						Contains("2 touch myfile-files"),
+					).
+					Select(Contains("touch myfile-files")).Confirm()
+			}).
+			Lines(
+				Contains("myfile-files"),
+			)
+
+		t.Views().Commits().
+			Focus().
+			Press("x").
+			Tap(func() {
+				t.ExpectPopup().Menu().
+					Title(Equals("My Custom Commands")).
+					Lines(
+						Contains("1 touch myfile-global"),
+						Contains("3 touch myfile-commits"),
+					)
+				t.GlobalPress("3")
+			})
+
+		t.Views().Files().
+			Lines(
+				Contains("myfile-commits"),
+				Contains("myfile-files"),
+			)
+	},
+})

--- a/pkg/integration/tests/custom_commands/global_context.go
+++ b/pkg/integration/tests/custom_commands/global_context.go
@@ -15,10 +15,9 @@ var GlobalContext = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig: func(cfg *config.AppConfig) {
 		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
 			{
-				Key:        "X",
-				Context:    "global",
-				Command:    "touch myfile",
-				ShowOutput: false,
+				Key:     "X",
+				Context: "global",
+				Command: "touch myfile",
 			},
 		}
 	},

--- a/pkg/integration/tests/custom_commands/multiple_contexts.go
+++ b/pkg/integration/tests/custom_commands/multiple_contexts.go
@@ -15,10 +15,9 @@ var MultipleContexts = NewIntegrationTest(NewIntegrationTestArgs{
 	SetupConfig: func(cfg *config.AppConfig) {
 		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
 			{
-				Key:        "X",
-				Context:    "commits, reflogCommits",
-				Command:    "touch myfile",
-				ShowOutput: false,
+				Key:     "X",
+				Context: "commits, reflogCommits",
+				Command: "touch myfile",
 			},
 		}
 	},

--- a/pkg/integration/tests/custom_commands/show_output_in_panel.go
+++ b/pkg/integration/tests/custom_commands/show_output_in_panel.go
@@ -15,18 +15,19 @@ var ShowOutputInPanel = NewIntegrationTest(NewIntegrationTestArgs{
 		shell.EmptyCommit("my change")
 	},
 	SetupConfig: func(cfg *config.AppConfig) {
+		trueVal := true
 		cfg.GetUserConfig().CustomCommands = []config.CustomCommand{
 			{
 				Key:        "X",
 				Context:    "commits",
 				Command:    "printf '%s' '{{ .SelectedLocalCommit.Name }}'",
-				ShowOutput: true,
+				ShowOutput: &trueVal,
 			},
 			{
 				Key:         "Y",
 				Context:     "commits",
 				Command:     "printf '%s' '{{ .SelectedLocalCommit.Name }}'",
-				ShowOutput:  true,
+				ShowOutput:  &trueVal,
 				OutputTitle: "Subject of commit {{ .SelectedLocalCommit.Hash }}",
 			},
 		}

--- a/pkg/integration/tests/status/log_cmd.go
+++ b/pkg/integration/tests/status/log_cmd.go
@@ -10,8 +10,7 @@ var LogCmd = NewIntegrationTest(NewIntegrationTestArgs{
 	ExtraCmdArgs: []string{},
 	Skip:         false,
 	SetupConfig: func(config *config.AppConfig) {
-		config.GetUserConfig().Git.AllBranchesLogCmd = `echo "view1"`
-		config.GetUserConfig().Git.AllBranchesLogCmds = []string{`echo "view2"`}
+		config.GetUserConfig().Git.AllBranchesLogCmds = []string{`echo "view1"`, `echo "view2"`}
 	},
 	SetupRepo: func(shell *Shell) {},
 	Run: func(t *TestDriver, keys config.KeybindingConfig) {

--- a/pkg/integration/tests/test_list.go
+++ b/pkg/integration/tests/test_list.go
@@ -140,6 +140,7 @@ var tests = []*components.IntegrationTest{
 	custom_commands.AccessCommitProperties,
 	custom_commands.BasicCommand,
 	custom_commands.CheckForConflicts,
+	custom_commands.CustomCommandsSubmenu,
 	custom_commands.FormPrompts,
 	custom_commands.GlobalContext,
 	custom_commands.MenuFromCommand,

--- a/schema/config.json
+++ b/schema/config.json
@@ -319,17 +319,15 @@
           "description": "Command used when displaying the current branch git log in the main window",
           "default": "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --"
         },
-        "allBranchesLogCmd": {
-          "type": "string",
-          "description": "Command used to display git log of all branches in the main window.\nDeprecated: Use `allBranchesLogCmds` instead.",
-          "default": "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"
-        },
         "allBranchesLogCmds": {
           "items": {
             "type": "string"
           },
           "type": "array",
-          "description": "Commands used to display git log of all branches in the main window, they will be cycled in order of appearance"
+          "description": "Commands used to display git log of all branches in the main window, they will be cycled in order of appearance",
+          "default": [
+            "git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium"
+          ]
         },
         "overrideGpg": {
           "type": "boolean",

--- a/schema/config.json
+++ b/schema/config.json
@@ -63,6 +63,13 @@
           "type": "string",
           "description": "The key to trigger the command. Use a single letter or one of the values from https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Custom_Keybindings.md"
         },
+        "commandMenu": {
+          "items": {
+            "$ref": "#/$defs/CustomCommand"
+          },
+          "type": "array",
+          "description": "Instead of defining a single custom command, create a menu of custom commands. Useful for grouping related commands together under a single keybinding, and for keeping them out of the global keybindings menu.\nWhen using this, all other fields except Key and Description are ignored and must be empty."
+        },
         "context": {
           "type": "string",
           "description": "The context in which to listen for the key. Valid values are: status, files, worktrees, localBranches, remotes, remoteBranches, tags, commits, reflogCommits, subCommits, commitFiles, stash, and global. Multiple contexts separated by comma are allowed; most useful for \"commits, subCommits\" or \"files, commitFiles\".",


### PR DESCRIPTION
- **PR Description**
A stacked PR on top of https://github.com/jesseduffield/lazygit/pull/4318. Will be changed into a cross-repository PR once that once merges. (The N+1 cost of adding a migration is lower now that I just have to modify a yaml.Node, and that's it!)

Solves the linked issue by migrating `allBranchesLogCmd` into the preferred `allBranchesLogCmds`. This would be breaking behavior if somebody was relying on the behavior in #3961, where they did not specify a `allBranchesLogCmd` element, and added some additional `allBranchesLogCmds` elements. Such a behavior was never documented, and relying on a deprecated element seems like user error. I would assume most people are like the one in the issue, where they assumed that they should put all of the items they want to cycle through in the `allBranchesLogCmds`, if they defined it.

Fixes https://github.com/jesseduffield/lazygit/issues/3961
- **Please check if the PR fulfills these requirements**

* [X] Cheatsheets are up-to-date (run `go generate ./...`)
* [X] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [X] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [X] If a new UserConfig entry was added, make sure it can be hot-reloaded (see [here](https://github.com/jesseduffield/lazygit/blob/master/docs/dev/Codebase_Guide.md#using-userconfig))
* [X] Docs have been updated if necessary
* [X] You've read through your own file changes for silly mistakes etc

